### PR TITLE
v2.6.0 - Allow a path before /favicon.ico

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.6.0 / 2020-03-10
+==================
+
+  * Allow a path before /favicon.ico for servers that might be behind a proxy, etc.
+
 2.5.0 / 2018-03-29
 ==================
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,16 @@ function favicon (path, options) {
   }
 
   return function favicon (req, res, next) {
-    if (getPathname(req) !== '/favicon.ico') {
+    var requestPathname = getPathname(req)
+
+    if (requestPathname === undefined) {
+      next()
+      return
+    }
+
+    var requestPathnameSegments = requestPathname.split('/')
+
+    if (requestPathnameSegments[requestPathnameSegments.length - 1] !== 'favicon.ico') {
       next()
       return
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serve-favicon",
   "description": "favicon serving middleware with caching",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": "Douglas Christopher Wilson <doug@somethingdoug.com>",
   "license": "MIT",
   "keywords": [

--- a/test/test.js
+++ b/test/test.js
@@ -184,6 +184,13 @@ describe('favicon()', function () {
         .expect(200, done)
     })
 
+    it('should work with path prefix', function (done) {
+      request(this.server)
+        .get('/some-path/favicon.ico')
+        .expect('Content-Type', 'image/x-icon')
+        .expect(200, done)
+    })
+
     describe('missing req.url', function () {
       it('should ignore the request', function (done) {
         var fn = favicon(ICON_PATH)


### PR DESCRIPTION
Allows a path such as `/some-path/favicon.ico`